### PR TITLE
pkg/bitstring: use word instead of uint32

### DIFF
--- a/generator/bitstring.go
+++ b/generator/bitstring.go
@@ -12,9 +12,5 @@ type Bitstring uint
 // Generate generates a random bit string in which the distribution of ones and
 // zeroes depends on rng.
 func (i Bitstring) Generate(rng *rand.Rand) interface{} {
-	bs, err := bitstring.Random(uint(i), rng)
-	if err != nil {
-		panic(err)
-	}
-	return bs
+	return bitstring.Random(uint(i), rng)
 }

--- a/generator/bitstring_test.go
+++ b/generator/bitstring_test.go
@@ -55,7 +55,7 @@ func TestBitstring(t *testing.T) {
 	t.Run("too many seed candidates", func(t *testing.T) {
 
 		f := Bitstring(length)
-		cand, _ := bitstring.New(length)
+		cand := bitstring.New(length)
 		// The following call should panic since the 3 seed candidates won't fit
 		// into a population of size 2.
 		seeds := []interface{}{cand, cand, cand}

--- a/operator/xover/bitstring_mater_test.go
+++ b/operator/xover/bitstring_mater_test.go
@@ -40,8 +40,8 @@ func TestBitstringCrossoveWithDifferentLengthParents(t *testing.T) {
 	rng := rand.New(rand.NewSource(99))
 	xover := New(BitstringMater{})
 
-	bs1, _ := bitstring.Random(32, rng)
-	bs2, _ := bitstring.Random(33, rng)
+	bs1 := bitstring.Random(32, rng)
+	bs2 := bitstring.Random(33, rng)
 	pop := []interface{}{bs1, bs2}
 
 	assert.Panics(t, func() {

--- a/pkg/bitstring/bench_test.go
+++ b/pkg/bitstring/bench_test.go
@@ -1,57 +1,23 @@
 package bitstring
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 )
 
-var sinka interface{}
-
-func BenchmarkBitstringCopy(b *testing.B) {
-	type run struct {
-		slen  uint
-		human string
-	}
-	runs := []run{
-		{1024, "1k"},
-		{100 * 1024, "100k"},
-		{10 * 1024 * 1024, "10M"},
-	}
-	for _, r := range runs {
-		b.Run(fmt.Sprintf("BenchBitstringCopy-%v", r.human), func(b *testing.B) {
-			var dst *Bitstring
-
-			// create original bitstring
-			rng := rand.New(rand.NewSource(99))
-			org, err := Random(r.slen, rng)
-			if err != nil {
-				b.Error("can't create rand bitstring:", err)
-			}
-
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				// actual benchmark
-				dst = Copy(org)
-			}
-			b.StopTimer()
-			sinka = dst
-		})
-	}
-}
-
-var sinkb uint32
+var sink interface{}
 
 func benchmarkUintn(b *testing.B, nbits, i uint) {
 	b.ReportAllocs()
 	bs, _ := MakeFromString("0000000000000000000000000000000101000000000000000000000000000000")
-	var v uint32
+	var v word
 	for n := 0; n < b.N; n++ {
 		v = bs.Uintn(nbits, i)
 	}
 	b.StopTimer()
-	sinkb = v
+	sink = v
 }
+
 func benchmarkUint32(b *testing.B, i uint) {
 	b.ReportAllocs()
 	bs, _ := MakeFromString("0000000000000000000000000000000101000000000000000000000000000000")
@@ -60,8 +26,9 @@ func benchmarkUint32(b *testing.B, i uint) {
 		v = bs.Uint32(i)
 	}
 	b.StopTimer()
-	sinkb = v
+	sink = v
 }
+
 func benchmarkUint16(b *testing.B, i uint) {
 	b.ReportAllocs()
 	bs, _ := MakeFromString("0000000000000000000000000000000101000000000000000000000000000000")
@@ -70,8 +37,9 @@ func benchmarkUint16(b *testing.B, i uint) {
 		v = bs.Uint16(i)
 	}
 	b.StopTimer()
-	sinkb = uint32(v)
+	sink = v
 }
+
 func benchmarkUint8(b *testing.B, i uint) {
 	b.ReportAllocs()
 	bs, _ := MakeFromString("0000000000000000000000000000000101000000000000000000000000000000")
@@ -80,7 +48,7 @@ func benchmarkUint8(b *testing.B, i uint) {
 		v = bs.Uint8(i)
 	}
 	b.StopTimer()
-	sinkb = uint32(v)
+	sink = v
 }
 
 func BenchmarkUintnSameWord(b *testing.B)        { benchmarkUintn(b, 32, 32) }
@@ -95,10 +63,59 @@ func BenchmarkUint8DifferentWords(b *testing.B)  { benchmarkUint8(b, 31) }
 func Benchmark_genmask(b *testing.B) {
 	b.ReportAllocs()
 
-	var v uint32
+	var v word
 	for i := 0; i < b.N; i++ {
 		v = genmask(4, 27)
 	}
 	b.StopTimer()
-	sinkb = v
+	sink = v
+}
+
+func Benchmark_lomask(b *testing.B) {
+	b.ReportAllocs()
+
+	var v word
+	for i := 0; i < b.N; i++ {
+		v = genlomask(27)
+	}
+	b.StopTimer()
+	sink = v
+}
+
+func BenchmarkSwapRange(b *testing.B) {
+	x := New(1026)
+	y := New(1026)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		SwapRange(x, y, 1, 1024)
+	}
+}
+
+func BenchmarkRandom(b *testing.B) {
+	var x *Bitstring
+
+	rng := rand.New(rand.NewSource(99))
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		x = Random(1026, rng)
+	}
+	b.StopTimer()
+	sink = x
+}
+
+func BenchmarkEquals(b *testing.B) {
+	rng := rand.New(rand.NewSource(99))
+	x := Random(1026, rng)
+	y := Copy(x)
+	var res bool
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		res = x.Equals(y)
+	}
+	b.StopTimer()
+	sink = res
 }

--- a/pkg/bitstring/bitops.go
+++ b/pkg/bitstring/bitops.go
@@ -1,35 +1,38 @@
 package bitstring
 
 // creates a mask keep the nth bit of a word.
-func bitmask(n uint) uint32 { return 1 << n }
+func bitmask(n uint) word { return 1 << n }
 
 // for a given bit of a bit string, returns the offset of the word
 // (from the first word of the bitstring) that contains that bit.
-func wordoffset(n uint) uint32 { return uint32(n / wordlen) }
+func wordoffset(n uint) word { return word(n / wordlen) }
 
 // for a given bit of a bit string, returns the offset of that bit
 // from the start of the word that contains it.
-func bitoffset(n uint) uint32 { return uint32(n & (wordlen - 1)) }
+func bitoffset(n uint) word { return word(n & (wordlen - 1)) }
 
-// returns a mask that keeps the bits in the range [l, h]
-func genmask(l, h uint) uint32 { return genlomask(h) & genhimask(l) }
+// returns a mask that keeps the bits in the range [l, h[
+// behaviour undefined if any argument is greater than wordlen.
+func genmask(l, h uint) word { return genlomask(h) & genhimask(l) }
 
-// returns a mask to keep the bits in the range [LSB, n]
-func genlomask(n uint) uint32 { return 1<<(n+1) - 1 }
+// returns a mask to keep the n LSB (least significant bits).
+// Undefined behaviour if n is greater than wordlen.
+func genlomask(n uint) word { return maxuword >> (wordlen - n) }
 
-// returns a mask to keep the bits in the range [n, MSB]
-func genhimask(n uint) uint32 { return maxuword << n }
+// returns a mask to keep the n MSB (most significan bits).
+// Undefined behaviour if n is greater than wordlen.
+func genhimask(n uint) word { return maxuword << n }
 
 // findFirstSetBit returns the offset of the first set bit in w
-func findFirstSetBit(w uint32) uint {
+func findFirstSetBit(w word) uint {
 	var num uint
 
-	//#if BITS_PER_LONG == 64
-	//if ((word & 0xffffffff) == 0) {
-	//num += 32;
-	//word >>= 32;
-	//}
-	//#endif
+	if wordlen == 64 {
+		if (w & 0xffffffff) == 0 {
+			num += 32
+			w >>= 32
+		}
+	}
 	if (w & 0xffff) == 0 {
 		num += 16
 		w >>= 16

--- a/pkg/bitstring/bitstring_test.go
+++ b/pkg/bitstring/bitstring_test.go
@@ -10,8 +10,7 @@ import (
 func TestBitstringCreation(t *testing.T) {
 	// Check that a bit string is constructed correctly, with
 	// the correct length and all bits initially set to zero.
-	bs, err := New(100)
-	assert.NoError(t, err)
+	bs := New(100)
 	assert.Equalf(t, bs.Len(), 100, "want Bitstring length 100, got: %v", bs.Len())
 	for i := 0; i < bs.Len(); i++ {
 		assert.False(t, bs.Bit(uint(i)), "Bit ", i, " should not be set.")
@@ -21,18 +20,16 @@ func TestBitstringCreation(t *testing.T) {
 func TestBitstringCreateRandomBitstring(t *testing.T) {
 	rng := rand.New(rand.NewSource(99))
 	// Check that a random bit string of the correct length is constructed.
-	bs, err := Random(100, rng)
-	assert.NoError(t, err)
+	bs := Random(100, rng)
 	assert.Equalf(t, bs.Len(), 100, "want Bitstring length 100, got: %v", bs.Len())
 }
 
 func TestBitstringSetBits(t *testing.T) {
 	// Make sure that bits are set correctly.
-	bs, err := New(5)
-	assert.NoError(t, err)
+	bs := New(5)
 
-	bs.SetBit(1, true)
-	bs.SetBit(4, true)
+	bs.SetBit(1)
+	bs.SetBit(4)
 
 	// Testing with non-symmetrical string to ensure that there are no endian
 	// or index problems.
@@ -43,14 +40,13 @@ func TestBitstringSetBits(t *testing.T) {
 	assert.True(t, bs.Bit(4), "Bit 4 should be set.")
 
 	// Test unsetting a bit.
-	bs.SetBit(4, false)
+	bs.ClearBit(4)
 	assert.False(t, bs.Bit(4), "Bit 4 should be unset.")
 }
 
 func TestBitstringFlipBits(t *testing.T) {
 	// Make sure bit-flipping works as expected.
-	bs, err := New(5)
-	assert.NoError(t, err)
+	bs := New(5)
 
 	bs.FlipBit(2)
 	assert.True(t, bs.Bit(2), "Flipping unset bit failed.")
@@ -61,12 +57,11 @@ func TestBitstringFlipBits(t *testing.T) {
 
 func TestBitstringToString(t *testing.T) {
 	// Checks that string representations are correctly generated.
-	bs, err := New(10)
-	assert.NoError(t, err)
+	bs := New(10)
 
-	bs.SetBit(3, true)
-	bs.SetBit(7, true)
-	bs.SetBit(8, true)
+	bs.SetBit(3)
+	bs.SetBit(7)
+	bs.SetBit(8)
 
 	// Testing with leading zero to make sure it isn't omitted.
 	want := "0110001000"
@@ -86,11 +81,10 @@ func TestBitstringParsing(t *testing.T) {
 
 // Checks that integer conversion is correct.
 func TestBitstringToNumber(t *testing.T) {
-	bs, err := New(10)
-	assert.NoError(t, err)
+	bs := New(10)
 
-	bs.SetBit(0, true)
-	bs.SetBit(9, true)
+	bs.SetBit(0)
+	bs.SetBit(9)
 	bint := bs.BigInt()
 	assert.True(t, bint.IsInt64())
 	assert.EqualValuesf(t, 513, bint.Int64(), "Incorrect big.Int conversion, want %v, got: %v", 513, bint.Int64())
@@ -98,83 +92,76 @@ func TestBitstringToNumber(t *testing.T) {
 
 func TestBitstringCountSetBits(t *testing.T) {
 	// Checks that the bit string can correctly count its number of set bits.
-	bs, err := New(64)
-	assert.NoError(t, err)
+	bs := New(64)
 	assert.Zerof(t, bs.OnesCount(), "Initial string should have no 1s, got: %v, repr \"%v\"", bs.OnesCount(), bs)
 
 	// The bits to set have been chosen because they deal with boundary cases.
-	bs.SetBit(0, true)
-	bs.SetBit(31, true)
-	bs.SetBit(32, true)
-	bs.SetBit(33, true)
-	bs.SetBit(63, true)
+	bs.SetBit(0)
+	bs.SetBit(31)
+	bs.SetBit(32)
+	bs.SetBit(33)
+	bs.SetBit(63)
 	setBits := bs.OnesCount()
 	assert.EqualValuesf(t, 5, setBits, "want set bits = 5, got: %v", setBits)
 }
 
 // Checks that the bit string can correctly count its number of unset bits.
 func TestBitstringCountUnsetBits(t *testing.T) {
-	bs, err := New(12)
-	assert.NoError(t, err)
+	bs := New(12)
 	assert.EqualValuesf(t, 12, bs.ZeroesCount(), "Initial string should have no 1s, got: %v, repr \"%v\"", bs.ZeroesCount(), bs)
 
-	bs.SetBit(0, true)
-	bs.SetBit(5, true)
-	bs.SetBit(6, true)
-	bs.SetBit(9, true)
-	bs.SetBit(10, true)
+	bs.SetBit(0)
+	bs.SetBit(5)
+	bs.SetBit(6)
+	bs.SetBit(9)
+	bs.SetBit(10)
 	setBits := bs.ZeroesCount()
 	assert.EqualValuesf(t, 7, setBits, "want set bits = 7, got: %v", setBits)
 }
 
-func TestBitstringClone(t *testing.T) {
-	bs, err := New(10)
-	assert.NoError(t, err)
-	bs.SetBit(3, true)
-	bs.SetBit(7, true)
-	bs.SetBit(8, true)
-	clone := Copy(bs)
+func TestBitstringCopy(t *testing.T) {
+	rng := rand.New(rand.NewSource(99))
+	bs := Random(2000, rng)
+	bs.SetBit(3)
+	bs.SetBit(7)
+	bs.SetBit(8)
+	cpy := Copy(bs)
 
-	// Check the clone is a bit-for-bit duplicate.
+	// Check the copy is a bit-for-bit duplicate.
 	for i := uint(0); i < uint(bs.Len()); i++ {
-		assert.Equalf(t, bs.Bit(i), clone.Bit(i), "Cloned bit string does not match in position %v", i)
+		assert.Equalf(t, bs.Bit(i), cpy.Bit(i), "copy differs original at bit %d", i)
 	}
 
-	// Check that clone is distinct from original (i.e. it does not change
-	// if the original is modified).
-	assert.False(t, clone == bs, "want clone and original different objects, got the same")
+	assert.False(t, cpy == bs, "copy and original should be different bitstring instances")
 	bs.FlipBit(2)
-	assert.False(t, clone.Bit(2), "Clone is not independent from original.")
+	assert.False(t, cpy.Bit(2) == bs.Bit(2), "copy and original are not independent from each other")
 }
 
 func TestBitstringEquality(t *testing.T) {
-	bs, err := New(10)
-	assert.NoError(t, err)
-	bs.SetBit(2, true)
-	bs.SetBit(5, true)
-	bs.SetBit(8, true)
+	bs := New(10)
+	bs.SetBit(2)
+	bs.SetBit(5)
+	bs.SetBit(8)
 
-	assert.True(t, bs.Equals(bs), "Bitstring should always equal itself.")
-	assert.False(t, bs.Equals(nil), "Valid Bitstring should never equal nil.")
-	assert.False(t, bs.Equals(&Bitstring{}), "Bitstring should not equal another instance")
+	assert.True(t, bs.Equals(bs), "Bitstring should always equals itself.")
+	assert.False(t, bs.Equals(nil), "Valid Bitstring should never equals nil.")
+	assert.False(t, bs.Equals(&Bitstring{}), "Bitstring should not equals another instance")
 
-	clone := Copy(bs)
-	assert.True(t, clone.Equals(bs), "Freshly cloned Bitstring should equal original")
+	cpy := Copy(bs)
+	assert.Truef(t, cpy.Equals(bs), "Freshly copied Bitstring should equals original, bs=%s copy=%s", bs, cpy)
 
 	// Changing one of the objects should result in them no longer being
 	// considered equal.
-	clone.FlipBit(0)
-	assert.False(t, clone.Equals(bs), "want different strings to cancel equality, \"%v\" and \"%s\"", clone, bs)
+	cpy.FlipBit(0)
+	assert.Falsef(t, cpy.Equals(bs), "bs=%s copy=%s", bs, cpy)
 
 	// Bit strings of different lengths but with the same bits set should not
 	// be considered equal.
-	var bs2 *Bitstring
-	bs2, err = New(9)
-	assert.NoError(t, err)
-	bs2.SetBit(2, true)
-	bs2.SetBit(5, true)
-	bs2.SetBit(8, true)
-	assert.False(t, bs2.Equals(bs), "want equal numbers but of different lengths to be considered not equal")
+	bs2 := New(9)
+	bs2.SetBit(2)
+	bs2.SetBit(5)
+	bs2.SetBit(8)
+	assert.False(t, bs2.Equals(bs))
 }
 
 func TestBitstringFromString(t *testing.T) {
@@ -188,7 +175,7 @@ func TestBitstringFromString(t *testing.T) {
 		{"only 0s", "0000", true},
 		{"only 1s", "1111111", true},
 		{"mixed 0s and 1s", "1000111011", true},
-		{"empty string", "", false},
+		{"empty string", "", true},
 		{"with spaces", "11 ", false},
 	}
 	for _, tt := range tests {
@@ -206,124 +193,138 @@ func TestBitstringFromString(t *testing.T) {
 }
 
 func TestBitstringSetBit(t *testing.T) {
-	bs, err := New(1)
-	assert.NoError(t, err)
-
+	bs := New(1)
 	t.Run("panics on index too high", func(t *testing.T) {
 		// The index of an individual bit must be within the range 0 to
 		// length-1.
-		assert.Panics(t, func() { bs.SetBit(1, false) })
+		assert.Panics(t, func() { bs.ClearBit(1) })
 	})
 }
 
 func TestBitstringSwapRange(t *testing.T) {
 	tests := []struct {
-		name              string
-		ones, zeros       string
-		lo, hi            uint // Bit indices are little-endian, so position 0 is the rightmost bit.
-		expOnes, expZeros string
+		x, y          string
+		start, length uint
+		wantx, wanty  string
 	}{
 		{
-			"word-aligned",
-			"1111111111111111111111111111111111111111111111111111111111111111",
-			"0000000000000000000000000000000000000000000000000000000000000000",
-			0, 32,
-			"1111111111111111111111111111111100000000000000000000000000000000",
-			"0000000000000000000000000000000011111111111111111111111111111111",
+			x:     "1",
+			y:     "0",
+			start: 0, length: 1,
+			wantx: "0",
+			wanty: "1",
 		},
 		{
-			"non-aligned start",
-			"1111111111111111111111111111111111111111",
-			"0000000000000000000000000000000000000000",
-			2, 30,
-			"1111111100000000000000000000000000000011",
-			"0000000011111111111111111111111111111100",
+			x:     "1111111111111111111111111111111111111111111111111111111111111111",
+			y:     "0000000000000000000000000000000000000000000000000000000000000000",
+			start: 0, length: 32,
+			wantx: "1111111111111111111111111111111100000000000000000000000000000000",
+			wanty: "0000000000000000000000000000000011111111111111111111111111111111",
 		},
 		{
-			"non-aligned end",
-			"1111111111",
-			"0000000000",
-			0, 3,
-			"1111111000",
-			"0000000111",
+			x:     "1111111111111111111111111111111111111111",
+			y:     "0000000000000000000000000000000000000000",
+			start: 2, length: 30,
+			wantx: "1111111100000000000000000000000000000011",
+			wanty: "0000000011111111111111111111111111111100",
 		},
 		{
-			"smaller than word length",
-			"111",
-			"000",
-			1, 2,
-			"001",
-			"110",
+			x:     "1111111111",
+			y:     "0000000000",
+			start: 0, length: 3,
+			wantx: "1111111000",
+			wanty: "0000000111",
 		},
 		{
-			"smaller than word length, full swap",
-			"111",
-			"000",
-			0, 3,
-			"000",
-			"111",
+			x:     "111",
+			y:     "000",
+			start: 1, length: 2,
+			wantx: "001",
+			wanty: "110",
 		},
 		{
-			"word length full swap",
-			"11111111111111111111111111111111",
-			"00000000000000000000000000000000",
-			0, 32,
-			"00000000000000000000000000000000",
-			"11111111111111111111111111111111",
+			x:     "111",
+			y:     "000",
+			start: 0, length: 3,
+			wantx: "000",
+			wanty: "111",
 		},
 		{
-			"greater than word length full swap",
-			"111111111111111111111111111111111",
-			"000000000000000000000000000000000",
-			0, 33,
-			"000000000000000000000000000000000",
-			"111111111111111111111111111111111",
+			x:     "11111111111111111111111111111111",
+			y:     "00000000000000000000000000000000",
+			start: 0, length: 32,
+			wantx: "00000000000000000000000000000000",
+			wanty: "11111111111111111111111111111111",
 		},
 		{
-			"smaller than 2 times word length full swap",
-			"111111111111111111111111111111111111111111111111111111111111111",
-			"000000000000000000000000000000000000000000000000000000000000000",
-			0, 63,
-			"000000000000000000000000000000000000000000000000000000000000000",
-			"111111111111111111111111111111111111111111111111111111111111111",
+			x:     "111111111111111111111111111111111",
+			y:     "000000000000000000000000000000000",
+			start: 0, length: 33,
+			wantx: "000000000000000000000000000000000",
+			wanty: "111111111111111111111111111111111",
 		},
 		{
-			"2 times word length full swap",
-			"1111111111111111111111111111111111111111111111111111111111111111",
-			"0000000000000000000000000000000000000000000000000000000000000000",
-			0, 64,
-			"0000000000000000000000000000000000000000000000000000000000000000",
-			"1111111111111111111111111111111111111111111111111111111111111111",
+			x:     "111111111111111111111111111111111111111111111111111111111111111",
+			y:     "000000000000000000000000000000000000000000000000000000000000000",
+			start: 0, length: 63,
+			wantx: "000000000000000000000000000000000000000000000000000000000000000",
+			wanty: "111111111111111111111111111111111111111111111111111111111111111",
 		},
 		{
-			"greater than 2 times word length full swap",
-			"11111111111111111111111111111111111111111111111111111111111111111",
-			"00000000000000000000000000000000000000000000000000000000000000000",
-			0, 65,
-			"00000000000000000000000000000000000000000000000000000000000000000",
-			"11111111111111111111111111111111111111111111111111111111111111111",
+			x:     "1111111111111111111111111111111111111111111111111111111111111111",
+			y:     "0000000000000000000000000000000000000000000000000000000000000000",
+			start: 0, length: 64,
+			wantx: "0000000000000000000000000000000000000000000000000000000000000000",
+			wanty: "1111111111111111111111111111111111111111111111111111111111111111",
 		},
 		{
-			"greater than 3 times word length",
-			"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-			"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-			94, 1,
-			"0111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-			"1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			x:     "11111111111111111111111111111111111111111111111111111111111111111",
+			y:     "00000000000000000000000000000000000000000000000000000000000000000",
+			start: 0, length: 65,
+			wantx: "00000000000000000000000000000000000000000000000000000000000000000",
+			wanty: "11111111111111111111111111111111111111111111111111111111111111111",
+		},
+		{
+			x:     "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+			y:     "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			start: 94, length: 1,
+			wantx: "1101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+			wanty: "0010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		},
+		{
+			x:     "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+			y:     "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			start: 1, length: 256,
+			wantx: "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+			wanty: "011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111110",
+		},
+		{
+			x:     "1111111111111111111111111111111111111111111111111111111111111111111",
+			y:     "0000000000000000000000000000000000000000000000000000000000000000000",
+			start: 64, length: 2,
+			wantx: "1001111111111111111111111111111111111111111111111111111111111111111",
+			wanty: "0110000000000000000000000000000000000000000000000000000000000000000",
+		},
+		{
+			x:     "1111111111111111111111111111111111111111111111111111111111111111111",
+			y:     "0000000000000000000000000000000000000000000000000000000000000000000",
+			start: 65, length: 1,
+			wantx: "1011111111111111111111111111111111111111111111111111111111111111111",
+			wanty: "0100000000000000000000000000000000000000000000000000000000000000000",
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ones, err1 := MakeFromString(tt.ones)
+		t.Run("", func(t *testing.T) {
+			x, err1 := MakeFromString(tt.x)
 			assert.NoError(t, err1)
-			zeros, err2 := MakeFromString(tt.zeros)
+			y, err2 := MakeFromString(tt.y)
 			assert.NoError(t, err2)
-			SwapRange(ones, zeros, tt.lo, tt.hi)
+			SwapRange(x, y, tt.start, tt.length)
 
-			assert.Equalf(t, tt.expOnes, ones.String(),
-				"want %s, got %s", tt.expOnes, ones.String())
-			assert.Equalf(t, tt.expZeros, zeros.String(),
-				"want %s, got %s", tt.expZeros, zeros.String())
+			assert.Equalf(t, tt.wantx, x.String(),
+				"want %s, got %s", tt.wantx, x.String())
+			assert.Equalf(t, tt.wanty, y.String(),
+				"want %s, got %s", tt.wanty, y.String())
 		})
 	}
 }

--- a/pkg/bitstring/convert.go
+++ b/pkg/bitstring/convert.go
@@ -2,19 +2,14 @@ package bitstring
 
 import (
 	"fmt"
-	"math"
-)
-
-const (
-	maxuword = math.MaxUint32
 )
 
 // Uintn returns the n-bit unsigned integer value represented by the n bits
 // starting at the bit index i. It panics if there are not enough bits or if n
 // is greater than 32.
 // TODO: reverse order of nbits and i params
-func (bs *Bitstring) Uintn(nbits, i uint) uint32 {
-	if nbits > 32 || nbits < 1 {
+func (bs *Bitstring) Uintn(nbits, i uint) word {
+	if nbits > wordlen || nbits < 1 {
 		panic(fmt.Sprintf("Uintn supports unsigned integers from 1 to %d bits long", wordlen))
 	}
 	bs.mustExist(i + nbits - 1)
@@ -25,29 +20,12 @@ func (bs *Bitstring) Uintn(nbits, i uint) uint32 {
 	loword := bs.data[j]
 	if j == k {
 		// fast path: same word
-		return (loword >> looff) & genlomask(nbits-1)
+		return (loword >> looff) & genlomask(nbits)
 	}
-	hioff := bitoffset(i + nbits - 1)
+	hioff := bitoffset(i + nbits)
 	hiword := bs.data[k] & genlomask(uint(hioff))
 	loword = genhimask(uint(looff)) & loword >> looff
 	return loword | hiword<<(wordlen-looff)
-}
-
-// Uint32 returns the uint32 value represented by the 32 bits starting at the
-// given bit. It panics if there are not enough bits.
-func (bs *Bitstring) Uint32(i uint) uint32 {
-	bs.mustExist(i + 31)
-
-	// fast path: i is a multiple of 32
-	if i&((1<<5)-1) == 0 {
-		return bs.data[i>>5]
-	}
-
-	word := wordoffset(i)
-	off := bitoffset(i)
-	loword := bs.data[word] >> off
-	hiword := bs.data[word+1] & ((1 << off) - 1)
-	return loword | hiword<<(wordlen-off)
 }
 
 // Uint16 returns the uint16 value represented by the 16 bits starting at the
@@ -98,6 +76,6 @@ func (bs *Bitstring) Int8(i uint) int8 {
 }
 
 // prints a string representing the first n bits of the base-2 representatio of x.
-func printbits(x uint32, n uint) {
+func printbits(x word, n uint) {
 	fmt.Printf(fmt.Sprintf("%%0%db\n", n), x)
 }

--- a/pkg/bitstring/convert_32.go
+++ b/pkg/bitstring/convert_32.go
@@ -1,0 +1,20 @@
+// +build 386 arm nacl mips mipsle
+
+package bitstring
+
+// Uint32 returns the uint32 value represented by the 32 bits starting at the
+// given bit. It panics if there are not enough bits.
+func (bs *Bitstring) Uint32(i uint) uint32 {
+	bs.mustExist(i + 31)
+
+	// fast path: i is a multiple of 32
+	if i&((1<<5)-1) == 0 {
+		return uint32(bs.data[i>>5])
+	}
+
+	w := wordoffset(i)
+	off := bitoffset(i)
+	loword := bs.data[w] >> off
+	hiword := bs.data[w+1] & ((1 << off) - 1)
+	return uint32(loword | hiword<<(wordlen-off))
+}

--- a/pkg/bitstring/convert_64.go
+++ b/pkg/bitstring/convert_64.go
@@ -1,0 +1,14 @@
+// +build amd64 arm64 mips64 mips64le ppc64 ppc64le s390x wasm
+
+package bitstring
+
+// Uint32 returns the uint32 value represented by the 32 bits starting at the
+// given bit. It panics if there are not enough bits.
+func (bs *Bitstring) Uint32(i uint) uint32 {
+	bs.mustExist(i + 31)
+
+	off := bitoffset(i)
+	loword := bs.data[wordoffset(i)] >> off
+	hiword := bs.data[wordoffset(i+31)] & ((1 << off) - 1)
+	return uint32(loword | hiword<<(wordlen-off))
+}

--- a/pkg/bitstring/convert_test.go
+++ b/pkg/bitstring/convert_test.go
@@ -13,7 +13,7 @@ func TestBitstringUintn(t *testing.T) {
 	tests := []struct {
 		input    string
 		nbits, i uint
-		want     uint32
+		want     word
 	}{
 		// LSB and MSB 8 are both on the same word
 		{input: "10",
@@ -91,7 +91,7 @@ func TestBitstringUint32(t *testing.T) {
 			got := bs.Uint32(tt.i)
 			if tt.want != got {
 				t.Errorf("Bitstring(%s).Uint32(%d) got %s, want %s", tt.input, tt.i,
-					sprintubits(uint32(got), 32), sprintubits(uint32(tt.want), 32))
+					sprintubits(word(got), 32), sprintubits(word(tt.want), 32))
 			}
 		})
 	}
@@ -132,7 +132,7 @@ func TestBitstringUint16(t *testing.T) {
 			got := bs.Uint16(tt.i)
 			if tt.want != got {
 				t.Errorf("Bitstring(%s).Uint16(%d) got %s, want %s", tt.input, tt.i,
-					sprintubits(uint32(got), 16), sprintubits(uint32(tt.want), 16))
+					sprintubits(word(got), 16), sprintubits(word(tt.want), 16))
 			}
 		})
 	}
@@ -173,7 +173,7 @@ func TestBitstringUint8(t *testing.T) {
 			got := bs.Uint8(tt.i)
 			if tt.want != got {
 				t.Errorf("Bitstring(%s).Uint8(%d) got %s, want %s", tt.input, tt.i,
-					sprintubits(uint32(got), 8), sprintubits(uint32(tt.want), 8))
+					sprintubits(word(got), 8), sprintubits(word(tt.want), 8))
 			}
 		})
 	}
@@ -210,7 +210,7 @@ func TestBitstringInt32(t *testing.T) {
 			got := bs.Int32(tt.i)
 			if tt.want != got {
 				t.Errorf("Bitstring(%s).Int32(%d) got %s, want %s", tt.input, tt.i,
-					sprintsbits(int32(got), 32), sprintsbits(int32(tt.want), 32))
+					sprintsbits(sword(got), 32), sprintsbits(sword(tt.want), 32))
 			}
 		})
 	}
@@ -244,7 +244,7 @@ func TestBitstringInt16(t *testing.T) {
 			got := bs.Int16(tt.i)
 			if tt.want != got {
 				t.Errorf("Bitstring(%s).Int16(%d) got %s, want %s", tt.input, tt.i,
-					sprintsbits(int32(got), 16), sprintsbits(int32(tt.want), 16))
+					sprintsbits(sword(got), 16), sprintsbits(sword(tt.want), 16))
 			}
 		})
 	}
@@ -280,7 +280,7 @@ func TestBitstringInt8(t *testing.T) {
 			got := bs.Int8(tt.i)
 			if tt.want != got {
 				t.Errorf("Bitstring(%s).Int8(%d) got %s, want %s", tt.input, tt.i,
-					sprintsbits(int32(got), 8), sprintsbits(int32(tt.want), 8))
+					sprintsbits(sword(got), 8), sprintsbits(sword(tt.want), 8))
 			}
 		})
 	}

--- a/pkg/bitstring/example_test.go
+++ b/pkg/bitstring/example_test.go
@@ -4,7 +4,7 @@ import "fmt"
 
 func ExampleNew() {
 	// create a 8 bits Bitstring
-	bitstring, _ := New(8)
+	bitstring := New(8)
 	// upon creation all bits are unset
 	fmt.Println(bitstring)
 	// Output: 00000000
@@ -19,24 +19,24 @@ func ExampleMakeFromString() {
 
 func ExampleBitstring_Len() {
 	// create a 8 bits Bitstring
-	bitstring, _ := New(8)
+	bitstring := New(8)
 	fmt.Println(bitstring.Len())
 	// Output: 8
 }
 
 func ExampleBitstring_Bit() {
 	// create a 8 bits Bitstring
-	bitstring, _ := New(8)
+	bitstring := New(8)
 	fmt.Println(bitstring.Bit(7))
 	// Output: false
 }
 
 func ExampleBitstring_SetBit() {
 	// create a 8 bits Bitstring
-	bitstring, _ := New(8)
-	bitstring.SetBit(2, true)
+	bitstring := New(8)
+	bitstring.SetBit(2)
 	fmt.Println(bitstring)
-	bitstring.SetBit(2, false)
+	bitstring.ClearBit(2)
 	fmt.Println(bitstring)
 	// Output: 00000100
 	// 00000000
@@ -44,7 +44,7 @@ func ExampleBitstring_SetBit() {
 
 func ExampleBitstring_FlipBit() {
 	// create a 8 bits Bitstring
-	bitstring, _ := New(8)
+	bitstring := New(8)
 	bitstring.FlipBit(2)
 	fmt.Println(bitstring)
 	// Output: 00000100
@@ -52,7 +52,7 @@ func ExampleBitstring_FlipBit() {
 
 func ExampleBitstring_ZeroesCount() {
 	// create a 8 bits Bitstring
-	bitstring, _ := New(8)
+	bitstring := New(8)
 	// upon creation all bits are unset
 	fmt.Println(bitstring.ZeroesCount())
 	// Output: 8
@@ -60,7 +60,7 @@ func ExampleBitstring_ZeroesCount() {
 
 func ExampleBitstring_OnesCount() {
 	// create a 8 bits Bitstring
-	bitstring, _ := New(8)
+	bitstring := New(8)
 	// upon creation all bits are unset
 	fmt.Println(bitstring.OnesCount())
 	// Output: 0

--- a/pkg/bitstring/helper_test.go
+++ b/pkg/bitstring/helper_test.go
@@ -4,16 +4,16 @@ import "fmt"
 
 // returns a string representing the first n bits of the base-2 representation
 // of x (unsigned).
-func sprintubits(val uint32, nbits uint) string {
+func sprintubits(val word, nbits uint) string {
 	return fmt.Sprintf(fmt.Sprintf("%%0%db", nbits), val)
 }
 
 // returns a string representing the first n bits of the base-2 representation
 // of x (signed).
-func sprintsbits(val int32, nbits uint) string {
+func sprintsbits(val sword, nbits uint) string {
 	if val < 0 {
 		// casting to uint will show us the 2's complement
-		return sprintubits(uint32(val), nbits)
+		return sprintubits(word(val), nbits)
 	}
 	return fmt.Sprintf(fmt.Sprintf("%%0%db", nbits), val)
 }

--- a/pkg/bitstring/word32.go
+++ b/pkg/bitstring/word32.go
@@ -1,0 +1,19 @@
+// +build 386 arm nacl mips mipsle
+
+package bitstring
+
+import "math"
+
+// word is a machine word
+type (
+	word  = uint32
+	sword = int32
+)
+
+const (
+	wordlen    = 32
+	logwordlen = 5
+	minsword   = math.MinInt32
+	maxsword   = math.MaxInt32
+	maxuword   = math.MaxUint32
+)

--- a/pkg/bitstring/word64.go
+++ b/pkg/bitstring/word64.go
@@ -1,0 +1,19 @@
+// +build amd64 arm64 mips64 mips64le ppc64 ppc64le s390x wasm
+
+package bitstring
+
+import "math"
+
+// word is a machine word
+type (
+	word  = uint64
+	sword = int64
+)
+
+const (
+	wordlen    = 64
+	logwordlen = 6
+	minsword   = math.MinInt64
+	maxsword   = math.MaxInt64
+	maxuword   = math.MaxUint64
+)


### PR DESCRIPTION
Depending on the platform, use a 32 or 64 bit word size